### PR TITLE
fix(idf): support ESP-IDF 6.0 / MbedTLS 4 for STARTTLS and OTA

### DIFF
--- a/components/idf_config/idf_config.cpp
+++ b/components/idf_config/idf_config.cpp
@@ -1,6 +1,7 @@
 #include "idf_config.h"
 
 #include <algorithm>
+#include <cstring>
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>

--- a/components/idf_push/idf_push.cpp
+++ b/components/idf_push/idf_push.cpp
@@ -31,12 +31,16 @@
 #include "idf_log.h"
 #include "idf_modem.h"
 #include "idf_wifi.h"
+#include "esp_idf_version.h"
 #include "mbedtls/base64.h"
-#include "mbedtls/ctr_drbg.h"
 #include "mbedtls/error.h"
 #include "mbedtls/md.h"
 #include "mbedtls/net_sockets.h"
 #include "mbedtls/ssl.h"
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+#include "mbedtls/ctr_drbg.h"
+#include "mbedtls/entropy.h"
+#endif
 #include "lwip/netdb.h"
 #include "lwip/sockets.h"
 
@@ -746,16 +750,21 @@ struct SmtpConn {
     mbedtls_net_context net;
     mbedtls_ssl_context ssl;
     mbedtls_ssl_config conf;
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+    // MbedTLS 3.x (IDF 5.x)：需要本地 entropy/ctr_drbg 作为 TLS 随机源
     mbedtls_ctr_drbg_context ctrDrbg;
     mbedtls_entropy_context entropy;
+#endif
 
     SmtpConn()
     {
         mbedtls_net_init(&net);
         mbedtls_ssl_init(&ssl);
         mbedtls_ssl_config_init(&conf);
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
         mbedtls_ctr_drbg_init(&ctrDrbg);
         mbedtls_entropy_init(&entropy);
+#endif
     }
 };
 
@@ -771,8 +780,10 @@ static void smtp_conn_close(SmtpConn& conn)
     }
     mbedtls_ssl_free(&conn.ssl);
     mbedtls_ssl_config_free(&conn.conf);
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
     mbedtls_ctr_drbg_free(&conn.ctrDrbg);
     mbedtls_entropy_free(&conn.entropy);
+#endif
     if (conn.sock >= 0) {
         close(conn.sock);
         conn.sock = -1;
@@ -862,6 +873,8 @@ static bool smtp_tcp_connect(const std::string& host, int port, SmtpConn& conn)
 
 static bool smtp_starttls_upgrade(SmtpConn& conn, const std::string& host)
 {
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+    // IDF 5.x / MbedTLS 3.x：显式初始化 CTR-DRBG，并通过 conf_rng 注入
     const char* pers = "sms-smtp-starttls";
     int ret = mbedtls_ctr_drbg_seed(&conn.ctrDrbg, mbedtls_entropy_func, &conn.entropy,
                                     reinterpret_cast<const unsigned char*>(pers), strlen(pers));
@@ -869,13 +882,19 @@ static bool smtp_starttls_upgrade(SmtpConn& conn, const std::string& host)
         idf_logf("STARTTLS随机源初始化失败: -0x%04x", -ret);
         return false;
     }
+#else
+    // IDF 6.x / MbedTLS 4.x：PSA Crypto RNG 全局生效，ctr_drbg/conf_rng 已移除
+    int ret = 0;
+#endif
     ret = mbedtls_ssl_config_defaults(&conn.conf, MBEDTLS_SSL_IS_CLIENT,
                                       MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_PRESET_DEFAULT);
     if (ret != 0) {
         idf_logf("STARTTLS配置初始化失败: -0x%04x", -ret);
         return false;
     }
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
     mbedtls_ssl_conf_rng(&conn.conf, mbedtls_ctr_drbg_random, &conn.ctrDrbg);
+#endif
     mbedtls_ssl_conf_authmode(&conn.conf, MBEDTLS_SSL_VERIFY_REQUIRED);
     if (esp_crt_bundle_attach(&conn.conf) != ESP_OK) {
         idf_log_line("STARTTLS证书包挂载失败");

--- a/components/idf_web/idf_web.cpp
+++ b/components/idf_web/idf_web.cpp
@@ -33,7 +33,7 @@
 #include "idf_sms.h"
 #include "idf_wifi.h"
 #include "mbedtls/base64.h"
-#include "mbedtls/sha256.h"
+#include "mbedtls/md.h"
 #include "nvs.h"
 #include "web_assets.h"
 
@@ -1761,11 +1761,17 @@ static esp_err_t handle_ota_update(httpd_req_t* req)
     size_t written = 0;
     char buf[1024];
     const size_t keep_tail = boundary_marker.size() + 8;
-    mbedtls_sha256_context sha_ctx;
+    // 使用通用 md API：IDF 6 / MbedTLS 4 已把 mbedtls/sha256.h 移入 private
+    mbedtls_md_context_t sha_ctx;
     bool sha_active = !expected_sha256.empty();
     if (sha_active) {
-        mbedtls_sha256_init(&sha_ctx);
-        mbedtls_sha256_starts(&sha_ctx, 0);
+        mbedtls_md_init(&sha_ctx);
+        const mbedtls_md_info_t* info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+        if (!info || mbedtls_md_setup(&sha_ctx, info, 0) != 0 || mbedtls_md_starts(&sha_ctx) != 0) {
+            mbedtls_md_free(&sha_ctx);
+            sha_active = false;
+            err = ESP_FAIL;
+        }
     }
 
     int timeouts = 0;
@@ -1808,9 +1814,9 @@ static esp_err_t handle_ota_update(httpd_req_t* req)
             err = esp_ota_write(ota, pending.data(), writable);
             if (err == ESP_OK) {
                 if (sha_active) {
-                    mbedtls_sha256_update(&sha_ctx,
-                                          reinterpret_cast<const unsigned char*>(pending.data()),
-                                          writable);
+                    mbedtls_md_update(&sha_ctx,
+                                      reinterpret_cast<const unsigned char*>(pending.data()),
+                                      writable);
                 }
                 written += writable;
                 pending.erase(0, writable);
@@ -1831,9 +1837,9 @@ static esp_err_t handle_ota_update(httpd_req_t* req)
                 }
                 if (err == ESP_OK) {
                     if (sha_active) {
-                        mbedtls_sha256_update(&sha_ctx,
-                                              reinterpret_cast<const unsigned char*>(pending.data()),
-                                              boundary);
+                        mbedtls_md_update(&sha_ctx,
+                                          reinterpret_cast<const unsigned char*>(pending.data()),
+                                          boundary);
                     }
                     written += boundary;
                 }
@@ -1845,14 +1851,17 @@ static esp_err_t handle_ota_update(httpd_req_t* req)
     if (err == ESP_OK && (!in_file || !saw_boundary || written == 0)) err = ESP_ERR_INVALID_SIZE;
     if (err == ESP_OK && sha_active) {
         unsigned char digest[32] = {};
-        mbedtls_sha256_finish(&sha_ctx, digest);
-        std::string actual = hex_lower(digest, sizeof(digest));
-        if (actual != expected_sha256) {
-            sha_mismatch = true;
-            err = ESP_ERR_INVALID_CRC;
+        if (mbedtls_md_finish(&sha_ctx, digest) != 0) {
+            err = ESP_FAIL;
+        } else {
+            std::string actual = hex_lower(digest, sizeof(digest));
+            if (actual != expected_sha256) {
+                sha_mismatch = true;
+                err = ESP_ERR_INVALID_CRC;
+            }
         }
     }
-    if (sha_active) mbedtls_sha256_free(&sha_ctx);
+    if (sha_active) mbedtls_md_free(&sha_ctx);
     if (err == ESP_OK) err = esp_ota_end(ota);
     else esp_ota_abort(ota);
     if (err == ESP_OK) err = esp_ota_set_boot_partition(part);


### PR DESCRIPTION
## Summary
- Gate SMTP STARTTLS entropy/ctr_drbg and `mbedtls_ssl_conf_rng` behind `ESP_IDF_VERSION < 6`, since MbedTLS 4 (IDF 6) uses the global PSA RNG and removed those public APIs.
- Switch OTA SHA-256 verification from `mbedtls/sha256.h` to the portable `mbedtls_md` API so it builds on IDF 6 where the dedicated SHA-256 header is private.
- Include `<cstring>` in config for `strlen` used by constant-time auth comparison.

Verified build, flash, and boot on ESP32-C3 with ESP-IDF **v6.0.1**. The 5.x code path is preserved for the existing CI (`espressif/idf:release-v5.5`) target.

## Test plan
- [x] `idf.py set-target esp32c3 && idf.py build` on ESP-IDF v6.0.1
- [x] Flash to ESP32-C3 and confirm serial boot (`sms_forwarding_idf` v1.0.8, web routes registered, modem AT ready)
- [ ] Confirm CI still green on release-v5.5
- [ ] Optional: exercise SMTP STARTTLS and OTA upload with SHA-256 checksum on a device running IDF 6 firmware