### PR TITLE
fix(wifi): 修复 STA 获取 IP 后崩溃的问题

### DIFF
--- a/components/idf_wifi/idf_wifi.cpp
+++ b/components/idf_wifi/idf_wifi.cpp
@@ -349,8 +349,9 @@ static void wifi_event_handler(void*, esp_event_base_t event_base, int32_t event
             idf_logf("WiFi 已连接，IP=" IPSTR, IP2STR(&event->ip_info.ip));
         }
         start_sntp_once();
-        // 同手机：成功连上的网络自动记住(任务内部去重，已知网络秒退不写 NVS)
-        if (xTaskCreate(wifi_remember_task, "idf_wifi_mem", 4096, nullptr, 2, nullptr) != pdPASS) {
+        // 同手机：成功连上的网络自动记住(任务内部去重，已知网络秒退不写 NVS)。
+        // 记忆路径会处理历史 WiFi 临时数组并保存 NVS，4KB 栈不足，使用独立 8KB 栈避免栈保护重启。
+        if (xTaskCreate(wifi_remember_task, "idf_wifi_mem", 8192, nullptr, 2, nullptr) != pdPASS) {
             ESP_LOGW(TAG, "WiFi 记忆任务创建失败，本次连接不自动记入历史列表");
         }
         if (s_wifi_event_group) {


### PR DESCRIPTION
## 问题现象

ESP32-C3 实机测试中，设备日志显示 Web 服务已注册，STA 已获取 DHCP 地址，例如 `192.168.0.198`。

随后设备出现 `Guru Meditation Error: Stack protection fault`，故障任务为 `idf_wifi_mem`。

实测表现是设备重启或失联后，路由器里仍可能看到 DHCP 租约，但浏览器无法访问设备 HTTP 页面；同时配网热点也可能不可见或不稳定，看起来像 WiFi 连上后设备直接失联。

## 根因

`IP_EVENT_STA_GOT_IP` 后创建的 `wifi_remember_task` 只有 4KB 栈。

该任务会处理历史 WiFi 临时数组、C++ 字符串，并执行 NVS 持久化。实机测试中该路径会触发 `idf_wifi_mem` 栈保护错误，导致设备重启。

## 修复

将 `idf_wifi_mem` 任务栈从 4KB 提升到 8KB。

该变更不修改 WiFi 状态机、历史 WiFi 逻辑或 NVS 数据格式，只为现有后台持久化路径提供足够栈余量。
