### PR TITLE
修复 CNUM 本机号码 +19 错号

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,5 +84,18 @@ jobs:
 
             | 文件 | 用途 |
             | --- | --- |
-            | `sms_forwarder_ota_v${{ steps.version.outputs.version }}.bin` | 网页「固件升级」页直接上传（OTA，无需数据线） |
-            | `sms_forwarder_full_v${{ steps.version.outputs.version }}.bin` | 整机烧录：`esptool.py --chip esp32c3 write_flash 0x0 <文件>` |
+            | `sms_forwarder_full_v${{ steps.version.outputs.version }}.bin` | 首次刷机、救砖、分区变化后重刷；从地址 `0x0` 整机刷写 |
+            | `sms_forwarder_ota_v${{ steps.version.outputs.version }}.bin` | 设备网页「固件升级」页直接上传（OTA，无需数据线） |
+
+            普通用户不需要下载源码，也不需要安装 Python/ESP-IDF。首次刷机推荐使用乐鑫官方 GUI 工具：
+
+            - Windows：[Flash Download Tool](https://docs.espressif.com/projects/esp-test-tools/en/latest/esp32c3/production_stage/tools/flash_download_tool.html)，选择 `ESP32-C3`，把 `sms_forwarder_full_v${{ steps.version.outputs.version }}.bin` 填到地址 `0x0`，选择实际串口和 `460800` 波特率后开始刷写。
+            - Chrome / Edge：[ESP Launchpad](https://espressif.github.io/esp-launchpad/) 自定义固件刷写，选择 `sms_forwarder_full_v${{ steps.version.outputs.version }}.bin`，地址填 `0x0`。
+
+            已经安装 Python/esptool 的高级用户，也可以用命令行刷完整包（按实际串口号替换 `COM5`）：
+
+            ```powershell
+            esptool.py --chip esp32c3 -p COM5 -b 460800 --before default_reset --after hard_reset write_flash --flash_mode dio --flash_freq 80m --flash_size 4MB 0x0 sms_forwarder_full_v${{ steps.version.outputs.version }}.bin
+            ```
+
+            OTA 升级：打开设备网页的「固件升级」页，上传 `sms_forwarder_ota_v${{ steps.version.outputs.version }}.bin`。不要把 `full` 包上传到网页 OTA，也不要把 `ota` 包从 `0x0` 当整机镜像刷写。

--- a/README.md
+++ b/README.md
@@ -242,11 +242,57 @@ start preview\index.html
 | --- | --- |
 | ![诊断与控制](assets/ui-diagnose.png) | ![系统日志](assets/ui-log.png) |
 
-## 烧录教程
+## 固件下载与刷写
 
-### 1. 准备环境
+普通用户不需要下载源码，也不需要安装 Python 或 ESP-IDF。到 GitHub Release 下载对应版本的 `.bin` 文件即可：
 
-推荐环境：
+| 文件 | 用途 | 使用场景 |
+| --- | --- | --- |
+| `sms_forwarder_full_v*.bin` | 整机刷写包，烧录地址 `0x0` | 首次刷机、救砖、分区表变化后重刷 |
+| `sms_forwarder_ota_v*.bin` | OTA 升级包，只包含 app 分区镜像 | 设备已经能打开 Web UI 时，在网页“固件升级”上传 |
+
+注意：`full` 包和 `ota` 包不能混用。首次刷机请把 `sms_forwarder_full_v*.bin` 写到 `0x0`；网页 OTA 只上传 `sms_forwarder_ota_v*.bin`。
+
+### 首次刷机（推荐 GUI）
+
+推荐用乐鑫官方图形工具，普通用户不用接触命令行：
+
+- Windows：使用 [Flash Download Tool](https://docs.espressif.com/projects/esp-test-tools/en/latest/esp32c3/production_stage/tools/flash_download_tool.html)。选择 `ESP32-C3`，模式选 `Develop`，下载方式选 `UART`，把 `sms_forwarder_full_v*.bin` 填到地址 `0x0`，选择实际 `COM` 口和波特率 `460800` 后点击 `START`。
+- Chrome / Edge：使用 [ESP Launchpad](https://espressif.github.io/esp-launchpad/) 的自定义固件刷写功能。连接设备后选择本地 `sms_forwarder_full_v*.bin`，地址填 `0x0`，再开始刷写。
+
+如果自动进入下载模式失败，可以按住开发板 `BOOT`，轻点 `RST/EN`，开始烧录后松开 `BOOT`。不同 ESP32-C3 开发板按钮名称可能不同，以板子丝印为准。
+
+### 首次刷机（开发者命令行）
+
+已经安装 Python/esptool 的用户，也可以直接用命令行刷完整包：
+
+```powershell
+esptool.py --chip esp32c3 -p COM5 -b 460800 --before default_reset --after hard_reset write_flash --flash_mode dio --flash_freq 80m --flash_size 4MB 0x0 sms_forwarder_full_v1.0.9-fork.4.bin
+```
+
+其中 `COM5` 和文件名按实际情况替换。`esptool.py` 是电脑端刷写工具，不在固件里；没有 Python 环境时请优先使用上面的 GUI 工具。
+
+### 后续 OTA 升级
+
+设备已经能进入 Web UI 时，不需要数据线：
+
+1. 打开设备网页。
+2. 进入“系统设置 / 固件升级 (OTA)”。
+3. 选择 `sms_forwarder_ota_v*.bin`。
+4. 可选填入 Release 页面提供的 OTA 包 SHA-256。
+5. 点击升级，等待设备自动重启。
+
+不要把 `sms_forwarder_full_v*.bin` 上传到网页 OTA。完整包包含 bootloader 和分区表，只适合从 `0x0` 串口整机刷写。
+
+### 首次访问 Web UI
+
+首次启动时设备会优先连接已保存 WiFi；如果没有配置或连接失败，会开启开放热点 `SMS-Forwarder-XXXX`。连接热点后访问 `http://192.168.1.1` 配网；设备连上路由器后，可通过串口日志里的 IP 地址或 `http://sms.local` 打开 Web UI（主机名可在“系统设置 → 局域网域名”中修改，多台设备请设置不同主机名）。
+
+默认账号密码为 `admin` / `admin123`，首次使用请立即修改。
+
+## 本地开发构建
+
+开发者需要本地编译固件时，再准备源码和 ESP-IDF：
 
 - Windows + PowerShell。
 - ESP32-C3 开发板或 ESP32-C3 Super Mini。
@@ -260,22 +306,12 @@ start preview\index.html
 Get-CimInstance Win32_SerialPort | Select-Object DeviceID,Description
 ```
 
-如果设备显示为 `COM5`，后续命令就使用 `-Port COM5`；如果是其他端口，把命令里的端口替换掉。
-
-### 2. 拉取并进入项目
+拉取并进入项目：
 
 ```powershell
 git clone https://github.com/MineSunshineone/sms_forwarding.git
 cd sms_forwarding
 ```
-
-已有仓库时直接进入项目目录即可：
-
-```powershell
-cd E:\GitHub-Repo\sms_forwarding
-```
-
-### 3. 构建固件
 
 仓库提供了 ESP-IDF 封装脚本，会自动加载 ESP-IDF 环境，并把构建产物放在 `build/idf`，把 `sdkconfig` 放在 `build/sdkconfig`：
 
@@ -290,27 +326,19 @@ python tools\build_web_assets.py
 python tools\build_web_assets.py --check
 ```
 
-### 4. 烧录到 ESP32-C3
+本地编译后烧录到 ESP32-C3：
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File tools\idf.ps1 flash -Port COM5
 ```
 
-如果自动进入下载模式失败，可以按住开发板 `BOOT`，轻点 `RST/EN`，开始烧录后松开 `BOOT`。不同 ESP32-C3 开发板按钮名称可能不同，以板子丝印为准。
-
-### 5. 打开串口日志
+打开串口日志：
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File tools\idf.ps1 monitor -Port COM5
 ```
 
 `monitor` 中可以看到 WiFi 连接、模组初始化、短信接收、推送、Web 访问和崩溃原因等日志。退出 monitor 通常使用 `Ctrl+]`。
-
-### 6. 首次访问 Web UI
-
-首次启动时设备会优先连接已保存 WiFi；如果没有配置或连接失败，会开启开放热点 `SMS-Forwarder-XXXX`。连接热点后访问 `http://192.168.1.1` 配网；设备连上路由器后，可通过串口日志里的 IP 地址或 `http://sms.local` 打开 Web UI（主机名可在"系统设置 → 局域网域名"中修改，多台设备请设置不同主机名）。
-
-默认账号密码为 `admin` / `admin123`，首次使用请立即修改。
 
 CI 使用 `.github/workflows/build.yml` 构建 ESP-IDF 固件，日常本地开发建议仍使用 `tools\idf.ps1`，这样构建目录和配置文件位置保持一致。
 

--- a/components/idf_modem/idf_modem.cpp
+++ b/components/idf_modem/idf_modem.cpp
@@ -758,6 +758,58 @@ static std::string parse_apn(const std::string& resp)
     }
 }
 
+// 部分模组/卡会把国际 TOA 字节 0x91 误解成 BCD 数字，导致 CNUM 号码出现
+// "+19..." 前缀，例如 +1944756... 实际应为 +44756...。这里只在 "19" 后
+// 紧跟常见国家/地区码时剥离，避免误伤真实 NANP 号码。
+static std::string normalize_msisdn(std::string phone)
+{
+    size_t start = 0;
+    while (start < phone.size() && isspace(static_cast<unsigned char>(phone[start]))) ++start;
+    size_t end = phone.size();
+    while (end > start && isspace(static_cast<unsigned char>(phone[end - 1]))) --end;
+    if (start >= end) return {};
+    phone = phone.substr(start, end - start);
+
+    bool had_plus = !phone.empty() && phone[0] == '+';
+    std::string digits;
+    digits.reserve(phone.size());
+    for (size_t i = had_plus ? 1 : 0; i < phone.size(); ++i) {
+        unsigned char ch = static_cast<unsigned char>(phone[i]);
+        if (isdigit(ch)) digits += static_cast<char>(ch);
+        else if (!isspace(ch) && ch != '-' && ch != '(' && ch != ')') {
+            return phone;
+        }
+    }
+    if (digits.size() < 8) return phone;
+    if (had_plus && digits.size() == 11 && digits[0] == '1') {
+        return std::string("+") + digits;
+    }
+
+    static const char* kCountryCodes[] = {
+        "44", "86", "33", "49", "81", "61", "91", "39", "34", "82", "65",
+        "852", "886", "853", "855", "856", "60", "62", "63", "66", "84",
+        "90", "971", "966", "974", "973", "968", "965", "962", "961",
+        "20", "27", "234", "254", "255", "256", "233", "212",
+        "7", "380", "48", "40", "36", "30", "31", "32",
+        "41", "43", "45", "46", "47", "351", "352", "353", "354", "358",
+        "420", "421", "370", "371", "372", "373", "374", "375", "376",
+        "52", "55", "54", "56", "57", "51", "58",
+        "1",
+    };
+    if (digits.rfind("19", 0) == 0) {
+        std::string rest = digits.substr(2);
+        for (const char* cc : kCountryCodes) {
+            size_t n = strlen(cc);
+            if (rest.size() < n + 6) continue;
+            if (rest.compare(0, n, cc) != 0) continue;
+            if (strcmp(cc, "1") == 0) continue;
+            return std::string("+") + rest;
+        }
+    }
+    if (had_plus) return std::string("+") + digits;
+    return phone;
+}
+
 static std::string parse_cnum_phone(const std::string& resp)
 {
     size_t p = resp.find("+CNUM:");
@@ -769,7 +821,8 @@ static std::string parse_cnum_phone(const std::string& resp)
     after_alpha = line.find('"', after_alpha + 1);
     if (after_alpha == std::string::npos) return {};
     std::string phone = first_quoted(line, after_alpha + 1);
-    return phone.empty() ? alpha : phone;
+    if (phone.empty()) phone = alpha;
+    return normalize_msisdn(phone);
 }
 
 static bool starts_with(const std::string& text, const char* prefix)

--- a/tests/test_cnum_normalization.py
+++ b/tests/test_cnum_normalization.py
@@ -1,0 +1,21 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class CnumNormalizationRegressionTests(unittest.TestCase):
+    def test_cnum_normalizes_toa_91_prefix_without_rewriting_nanp(self):
+        modem = (ROOT / "components/idf_modem/idf_modem.cpp").read_text(encoding="utf-8")
+
+        self.assertIn("normalize_msisdn", modem)
+        self.assertIn('digits.rfind("19", 0) == 0', modem)
+        self.assertIn("had_plus && digits.size() == 11 && digits[0] == '1'", modem)
+        self.assertIn('strcmp(cc, "1") == 0', modem)
+        self.assertRegex(modem, r"parse_cnum_phone[\s\S]*return normalize_msisdn\(phone\)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### 故障现象

我的两个gg号一个是+44开头正确，另一个是+1944开头，明显错误。

部分 SIM/模组执行 `AT+CNUM` 读取本机号码时，会把国际 TOA 字节 `0x91` 误读进号码文本，导致状态页或转发占位符显示类似 `+194475...` 的错号。实际号码应为 `+4475...` 这类国际号码。

### 缺陷原因

当前 `parse_cnum_phone()` 直接使用 CNUM 返回的号码字段，没有对这种 `+19...` 异常前缀做归一化处理。

### 解决办法

新增 `normalize_msisdn()`：
- 去除空格、短横线、括号等展示字符。
- 仅在 `19` 后紧跟常见非 NANP 国家/地区码时剥离错误前缀。
- 显式保护有效的北美 `+1XXXXXXXXXX` 号码，避免误改。