### PR TITLE
修复 ESP32-C3 SuperMini 天线缺陷导致 WiFi 无法连接：限制发射功率至 8.5dBm

### DIFF
--- a/components/idf_wifi/idf_wifi.cpp
+++ b/components/idf_wifi/idf_wifi.cpp
@@ -1113,6 +1113,14 @@ esp_err_t idf_wifi_start(const IdfConfig& config)
         return err;
     }
     s_started.store(true, std::memory_order_relaxed);
+    // ESP32-C3 SuperMini 板载天线匹配差，满功率发射时信号失真，AP 收不到认证帧，
+    // 表现为 auth (0xb0) -> init (0x200) 认证超时循环。限制到 8.5dBm 后可稳定连接。
+    // 单位 0.25dBm：34 * 0.25 = 8.5dBm
+    err = esp_wifi_set_max_tx_power(34);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "esp_wifi_set_max_tx_power failed: %s", esp_err_to_name(err));
+        idf_logf("限制 WiFi 发射功率失败: %s", esp_err_to_name(err));
+    }
     start_mdns_task_once();
     // 3072：任务里 start_provisioning_ap 会用到 wifi_config_t(~132B) + 日志格式化缓冲
     {


### PR DESCRIPTION
## 问题现象

MakerGO ESP32-C3 SuperMini（README 推荐硬件）烧录 v1.0.9 full 包后无法连接 WiFi。串口持续循环：

```
I (1114) wifi:state: init -> auth (0xb0)
I (2115) wifi:state: auth -> init (0x200)   ← 认证 1 秒无应答超时
W (...)  wifi:Haven't to connect to a suitable AP now!   ← 持续刷屏
```

同时配网热点 `SMS-Forwarder-XXXX` 在 0.5 米内的电脑上也完全扫不到。已排除热点频段（2.4G）、密码、信道等常规原因。

## 根因

C3 SuperMini 板载天线匹配电路存在社区广泛报告的设计缺陷：满功率（默认约 20dBm）发射时信号严重失真。与日志现象完全吻合：

- 能进入 `auth` 状态 → 扫描收到了 AP beacon、锁定了目标 BSSID，**接收方向基本正常**；
- `auth` 1 秒超时回 `init` → 设备发出的认证帧 AP 根本收不到，**发送方向失真**；
- 同理 softAP 的 beacon 也发不出去，配网热点近在咫尺也搜不到。

## 修复

`esp_wifi_start()` 成功后调用 `esp_wifi_set_max_tx_power(34)`（单位 0.25dBm，即 8.5dBm）。这是社区针对该板的通行 workaround。

## 实测（同一设备、同一热点，前后对比）

修复前：auth 超时循环稳定复现，40 秒内 12+ 次尝试全部失败。

修复后：

```
I (1035) wifi:state: init -> auth (0xb0)
I (1046) wifi:state: auth -> assoc (0x0)
I (1052) wifi:state: assoc -> run (0x10)
I (1066) wifi:connected with xxx, aid = 26, channel 3, BW20
I (2118) esp_netif_handlers: sta ip: x.x.x.x
```

认证 11ms 通过，2.1 秒拿到 IP，此后长时间运行无断连、无异常日志。

交叉验证：同一块板在旧 Arduino 版固件上加 `WiFi.setTxPower(WIFI_POWER_8_5dBm)` 后，同样从"完全连不上"变为稳定连接——两套固件栈、同一处修复、同一结果，根因指向硬件发射功率而非某一版软件。

## 为什么建议合并

1. **命中推荐硬件的开箱路径**。README 推荐的就是 C3 SuperMini；按清单采购的新用户第一步就会遇到"配网热点搜不到 + WiFi 连不上"，不接串口无从排查，很容易直接判定"设备是坏的"而退货弃坑。
2. **改动小、风险低**。单文件 8 行，不涉及 API、配置面、分区布局或行为兼容性。
3. **代价可忽略**。短信转发器的典型部署是与路由器同室常驻，8.5dBm 覆盖完全够用；相比"完全无法使用"，发射功率上限的损失不构成实际代价。天线正常的板子只是功率变低，不受影响。
4. **可演进**。若后续想精细化（如 NVS/网页可配置），可在此基础上加配置项，默认值建议保持 8.5dBm 以保证推荐硬件开箱可用；需要的话我可以跟进。

## 测试环境

- 硬件：MakerGO ESP32-C3 SuperMini（4MB flash）
- 基线：master `2e32083`（v1.0.9），ESP-IDF v5.5.5 官方离线包编译
- 验证方式：full 包 `0x0` 整机刷写后，仅替换 `app0` 对比验证本补丁
