### PR TITLE
fix(esim): reuse logical channel during BPP profile download

### DIFF
--- a/components/idf_esim/idf_esim.cpp
+++ b/components/idf_esim/idf_esim.cpp
@@ -1236,7 +1236,7 @@ IdfEsimLpaBppSession::~IdfEsimLpaBppSession()
 
 esp_err_t IdfEsimLpaBppSession::begin_segment(std::string& safe_message)
 {
-    close();
+    if (impl_) return ESP_OK;
     auto* impl = new (std::nothrow) IdfEsimLpaBppSessionImpl();
     if (!impl) {
         safe_message = "BPP segment 会话内存不足";

--- a/components/idf_lpa/idf_lpa.cpp
+++ b/components/idf_lpa/idf_lpa.cpp
@@ -1444,10 +1444,8 @@ public:
 
     esp_err_t begin(std::string& message)
     {
-        close();
-        pending_size_ = 0;
-        block_number_ = 0;
-        clear_sensitive_bytes(last_response_);
+        if (active_) close();
+        reset_segment_state();
         active_ = true;
         esp_err_t err = session_.begin_segment(message);
         if (err != ESP_OK) active_ = false;
@@ -1498,23 +1496,28 @@ public:
         }
         esp_err_t err = flush(true, message);
         if (err == ESP_OK) response = std::move(last_response_);
-        close();
+        reset_segment_state();
         return err;
     }
 
     void close()
     {
         session_.close();
+        reset_segment_state();
+        clear_sensitive_bytes(last_response_);
+    }
+
+private:
+    void reset_segment_state()
+    {
         active_ = false;
         volatile uint8_t* pending_bytes = pending_.data();
         for (size_t i = 0; i < pending_.size(); ++i) pending_bytes[i] = 0;
         pending_size_ = 0;
         segment_bytes_ = 0;
         block_number_ = 0;
-        clear_sensitive_bytes(last_response_);
     }
 
-private:
     esp_err_t flush(bool last, std::string& message)
     {
         if (pending_size_ == 0 || block_number_ > 0xFFU) {


### PR DESCRIPTION
修复 eSIM Profile 下载过程中 BPP 分段写卡失败的问题 ( 实测写voxi卡时失败，修复后写入成功)。

实测现象从“APDU 分段响应过多”开始，后续还可能表现为“APDU 响应过大”或在 sequenceOf88Header 阶段返回卡策略拒绝，例如 SW=6985。

根因是 LoadBPP 是跨多个 STORE DATA segment 的状态机流程，原实现每个 BPP segment begin/finish 都重新打开并关闭 eUICC 逻辑通道，部分 eUICC 会丢失前序状态，导致后续 segment 写入失败。

修复方式是让 IdfEsimLpaBppSession 在整个 BPP parser 生命周期内复用同一个逻辑通道。单个 segment 完成后只清理本段 pending 缓冲、块号和长度状态，整个 BPP 下载完成或失败时再关闭底层会话。

本地实测修复后 GetBPP 可完成，segments=24，最终显示“下载 eSIM Profile: 完成”。